### PR TITLE
Fix: if user provided y domain, don't modify it

### DIFF
--- a/.changeset/perfect-kangaroos-press.md
+++ b/.changeset/perfect-kangaroos-press.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+If user provided y domain, don't modify it

--- a/lib/src/cartesian/utils/transformInputData.test.ts
+++ b/lib/src/cartesian/utils/transformInputData.test.ts
@@ -64,5 +64,20 @@ describe("transformInputData", () => {
     expect(y.y.i).toEqual([7, 5, 3]);
   });
 
+  it("should use domain if provided", () => {
+    const { xScale, yScale } = transformInputData({
+      data: DATA,
+      xKey: "x",
+      yKeys: ["y", "z"],
+      outputWindow: OUTPUT_WINDOW,
+      domain: { x: [0, 2.5], y: [0, 1.5] },
+    });
+
+    expect(xScale(0)).toEqual(0);
+    expect(xScale(2.5)).toEqual(500);
+    expect(yScale(0)).toEqual(300);
+    expect(yScale(1.5)).toEqual(0);
+  });
+
   // TODO: Some day, test the gridOptions code.
 });

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -138,7 +138,8 @@ export const transformInputData = <
   const yScale = makeScale({
     inputBounds: yScaleDomain,
     outputBounds: yScaleRange,
-    isNice: true,
+    // If user provided a domain, don't modify it
+    isNice: domain?.y?.[1] ? false : true,
     padEnd:
       typeof domainPadding === "number" ? domainPadding : domainPadding?.bottom,
     padStart:


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Make `isNice` param to `makeScale` conditional, false if user y domain is defined.

Fixes # (issue)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Added a unit test for `transformInputData` to verify that user-defined domain is preserved.

